### PR TITLE
Make Express and Promt memory configurable

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -229,6 +229,7 @@ addDataset(tier0Config, "Default",
            blockCloseDelay=24 * 3600,
            timePerEvent=5,
            sizePerEvent=1500,
+           maxMemoryperCore=2000,
            scenario=ppScenario)
 
 #############################
@@ -259,6 +260,7 @@ addExpressConfig(tier0Config, "Express",
                  blockCloseDelay=1200,
                  timePerEvent=4,
                  sizePerEvent=1700,
+                 maxMemoryperCore=2000,
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "ExpressCosmics",
@@ -284,6 +286,7 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  blockCloseDelay=1200,
                  timePerEvent=4, #I have to get some stats to set this properly
                  sizePerEvent=1700, #I have to get some stats to set this properly
+                 maxMemoryperCore=2000,
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "HLTMonitor",
@@ -307,6 +310,7 @@ addExpressConfig(tier0Config, "HLTMonitor",
                  blockCloseDelay=1200,
                  timePerEvent=4, #I have to get some stats to set this properly
                  sizePerEvent=1700, #I have to get some stats to set this properly
+                 maxMemoryperCore=2000,
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "Calibration",
@@ -329,6 +333,7 @@ addExpressConfig(tier0Config, "Calibration",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
+                 maxMemoryperCore=2000,
                  archivalNode="T0_CH_CERN_MSS",
                  dataType="data",
                  tape_node="T1_US_FNAL_MSS")
@@ -354,6 +359,7 @@ addExpressConfig(tier0Config, "ExpressAlignment",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
+                 maxMemoryperCore=2000,
                  diskNode="T2_CH_CERN")
 
 addExpressConfig(tier0Config, "ALCALUMIPIXELSEXPRESS",
@@ -377,6 +383,7 @@ addExpressConfig(tier0Config, "ALCALUMIPIXELSEXPRESS",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
+                 maxMemoryperCore=2000,
                  archivalNode=None,
                  tapeNode=None,
                  diskNode=None)
@@ -410,6 +417,7 @@ addExpressConfig(tier0Config, "HIExpress",
                  blockCloseDelay=1200,
                  timePerEvent=4,
                  sizePerEvent=1700,
+                 maxMemoryperCore=2000,
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "HIExpressAlignment",
@@ -434,6 +442,7 @@ addExpressConfig(tier0Config, "HIExpressAlignment",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
+                 maxMemoryperCore=2000,
                  diskNode="T2_CH_CERN")
 
 ###################################

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -222,6 +222,7 @@ addDataset(tier0Config, "Default",
            blockCloseDelay=1200,
            timePerEvent=5,
            sizePerEvent=1500,
+           maxMemoryperCore=2000,
            scenario=ppScenario)
 
 #############################
@@ -250,6 +251,7 @@ addExpressConfig(tier0Config, "Express",
                  blockCloseDelay=1200,
                  timePerEvent=4,
                  sizePerEvent=1700,
+                 maxMemoryperCore=2000,
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "ExpressCosmics",
@@ -275,6 +277,7 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  blockCloseDelay=1200,
                  timePerEvent=4, #I have to get some stats to set this properly
                  sizePerEvent=1700, #I have to get some stats to set this properly
+                 maxMemoryperCore=2000,
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "HLTMonitor",
@@ -298,6 +301,7 @@ addExpressConfig(tier0Config, "HLTMonitor",
                  blockCloseDelay=1200,
                  timePerEvent=4, #I have to get some stats to set this properly
                  sizePerEvent=1700, #I have to get some stats to set this properly
+                 maxMemoryperCore=2000,
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "Calibration",
@@ -320,9 +324,10 @@ addExpressConfig(tier0Config, "Calibration",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
+                 maxMemoryperCore=2000,
                  dataType="data",
                  diskNode="T0_CH_CERN_Disk")
- 
+
 addExpressConfig(tier0Config, "ExpressAlignment",
                  scenario=alcaTrackingOnlyScenario,
                  data_tiers=["ALCARECO"],
@@ -344,6 +349,7 @@ addExpressConfig(tier0Config, "ExpressAlignment",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
+                 maxMemoryperCore=2000,
                  diskNode="T0_CH_CERN_Disk")
 
 addExpressConfig(tier0Config, "ALCALUMIPIXELSEXPRESS",
@@ -367,6 +373,7 @@ addExpressConfig(tier0Config, "ALCALUMIPIXELSEXPRESS",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
+                 maxMemoryperCore=2000,
                  diskNode="T0_CH_CERN_Disk")
 
 #####################
@@ -397,6 +404,7 @@ addExpressConfig(tier0Config, "HIExpress",
                  blockCloseDelay=1200,
                  timePerEvent=4,
                  sizePerEvent=1700,
+                 maxMemoryperCore=2000,
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "HIExpressAlignment",
@@ -421,6 +429,7 @@ addExpressConfig(tier0Config, "HIExpressAlignment",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
+                 maxMemoryperCore=2000,
                  diskNode="T0_CH_CERN_Disk")
 
 ###################################

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -616,18 +616,10 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['TimePerEvent'] = streamConfig.Express.TimePerEvent
             specArguments['SizePerEvent'] = streamConfig.Express.SizePerEvent
 
-            if streamConfig.Express.Scenario == "HeavyIonsRun2":
-                baseMemory = 3000
-                perCoreMemory = 1300
-            else:
-                baseMemory = 3500
-                perCoreMemory = 1050
-
-            specArguments['Memory'] = baseMemory + perCoreMemory
-
+            specArguments['Memory'] = streamConfig.Express.MaxMemoryperCore
             if streamConfig.Express.Multicore:
                 specArguments['Multicore'] = streamConfig.Express.Multicore
-                specArguments['Memory'] += (streamConfig.Express.Multicore - 1) * perCoreMemory
+                specArguments['Memory'] += (streamConfig.Express.Multicore - 1) * streamConfig.Express.MaxMemoryperCore
 
             specArguments['Requestor'] = "Tier0"
             specArguments['RequestName'] = workflowName
@@ -1047,20 +1039,10 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                 specArguments['TimePerEvent'] = datasetConfig.TimePerEvent
                 specArguments['SizePerEvent'] = datasetConfig.SizePerEvent
 
-                if datasetConfig.Scenario == "HeavyIonsRun2":
-                    baseMemory = 3000
-                    perCoreMemory = 1300
-                else:
-                    baseMemory = 3500
-                    perCoreMemory = 1050
-
-                specArguments['Memory'] = baseMemory + perCoreMemory
-
+                specArguments['Memory'] = datasetConfig.MaxMemoryperCore
                 if datasetConfig.Multicore:
                     specArguments['Multicore'] = datasetConfig.Multicore
-                    specArguments['Memory'] += (datasetConfig.Multicore - 1) * perCoreMemory
-
-                specArguments['Memory'] += len(datasetConfig.PhysicsSkims) * 100
+                    specArguments['Memory'] += (datasetConfig.Multicore - 1) * datasetConfig.MaxMemoryperCore
 
                 specArguments['Requestor'] = "Tier0"
                 specArguments['RequestName'] = workflowName

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -556,6 +556,11 @@ def addDataset(config, datasetName, **settings):
     datasetConfig.PhysicsSkims = settings.get("physics_skims", [])
     datasetConfig.DqmSequences = settings.get("dqm_sequences", [])
 
+    if hasattr(datasetConfig, "MaxMemoryperCore"):
+        datasetConfig.MaxMemoryperCore = settings.get("maxMemoryperCore", datasetConfig.MaxMemoryperCore)
+    else:
+        datasetConfig.MaxMemoryperCore = settings.get("maxMemoryperCore", 2000)
+
     return
 
 def setAcquisitionEra(config, acquisitionEra):
@@ -931,6 +936,11 @@ def addExpressConfig(config, streamName, **options):
     streamConfig.Express.PhEDExGroup = options.get("phedexGroup", "express")
 
     streamConfig.Express.BlockCloseDelay = options.get("blockCloseDelay", 3600)
+
+    if hasattr(streamConfig.Express, "MaxMemoryperCore"):
+        streamConfig.Express.MaxMemoryperCore = options.get("maxMemoryperCore", streamConfig.Express.MaxMemoryperCore)
+    else:
+        streamConfig.Express.MaxMemoryperCore = options.get("maxMemoryperCore", 2000)
 
     return
 


### PR DESCRIPTION
Add an option to configure the max memory per core for Express and Promt given by: baseMem(500)+MaxMemperCore(default:2000) + 100*(Skims)

